### PR TITLE
Presenter view context

### DIFF
--- a/app/helpers/mountain_view/component_helper.rb
+++ b/app/helpers/mountain_view/component_helper.rb
@@ -2,7 +2,7 @@ module MountainView
   module ComponentHelper
     def render_component(slug, properties = {})
       component = MountainView::Presenter.component_for(slug, properties)
-      component.render(self)
+      component.render(controller.view_context)
     end
   end
 end

--- a/app/helpers/mountain_view/component_helper.rb
+++ b/app/helpers/mountain_view/component_helper.rb
@@ -2,7 +2,7 @@ module MountainView
   module ComponentHelper
     def render_component(slug, properties = {})
       component = MountainView::Presenter.component_for(slug, properties)
-      render partial: component.partial, locals: component.locals
+      component.render(self)
     end
   end
 end

--- a/lib/mountain_view.rb
+++ b/lib/mountain_view.rb
@@ -1,6 +1,7 @@
 require "mountain_view/version"
 require "mountain_view/configuration"
 require "mountain_view/presenter"
+require "mountain_view/component"
 
 module MountainView
   def self.configuration

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -1,6 +1,4 @@
 require "rails"
-require "mountain_view"
-require "mountain_view/component"
 
 module MountainView
   class Engine < ::Rails::Engine

--- a/lib/mountain_view/presenter.rb
+++ b/lib/mountain_view/presenter.rb
@@ -7,7 +7,7 @@ module MountainView
 
     def initialize(slug, properties = {})
       @slug = slug
-      @properties = property_defaults.deep_merge(properties)
+      @properties = default_properties.deep_merge(properties)
     end
 
     def render(context)
@@ -22,7 +22,7 @@ module MountainView
 
     private
 
-    def property_defaults
+    def default_properties
       self.class._properties.inject({}) do |sum, (k, v)|
         sum[k] = v[:default]
         sum
@@ -42,12 +42,14 @@ module MountainView
           sum[name] = opts
           sum
         end
-        define_property_methods(*args)
+        define_property_methods(args)
         self._properties = _properties.merge(properties)
       end
       alias_method :property, :properties
 
-      def define_property_methods(*names)
+      private 
+      
+      def define_property_methods(names=[])
         names.each do |name|
           next if method_defined?(name) 
           define_method name do

--- a/lib/mountain_view/presenter.rb
+++ b/lib/mountain_view/presenter.rb
@@ -11,7 +11,6 @@ module MountainView
     end
 
     def render(context)
-      context = context.clone
       context.extend ViewContext
       context.inject_component_context(self)
       context.render partial: partial

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -7,12 +7,12 @@
   <% end %>
   <div class="card__content">
     <h3 class="card__content__title">
-      <a href="<%= properties[:link] %>"><%= properties[:title] %></a>
+      <a href="<%= properties[:link] %>"><%= title %></a>
     </h3>
-    <%- if properties[:description] %>
+    <%- if has_description? %>
       <p><%= properties[:description] %></p>
     <%- end %>
-    <%= foobar %>
+    <p>Location: <%= location %></p>
     <div class="card__content__data">
       <%- if properties[:data] && properties[:data].any? %>
         <%- properties[:data].each do |data| %>

--- a/test/dummy/app/components/card/card.yml
+++ b/test/dummy/app/components/card/card.yml
@@ -1,5 +1,6 @@
 -
-  :title: "Aspen Snowmass"
+  :title: "Snowmass"
+  :location: "Aspen"
   :description: "Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado in the United States. Owned and operated by the Aspen Skiing Company it comprises four skiing/snowboarding areas on four adjacent mountains in the vicinity of the towns of Aspen and Snowmass Village."
   :link: "http://google.com"
   :image_url: "http://i.imgur.com/QzuIJTo.jpg"
@@ -13,7 +14,8 @@
 
 
 -
-  :title: "Breckenridge, Colorado"
+  :title: "Breckenridge"
+  :location: "Colorado"
   :link: "http://facebook.com"
   :image_url: "http://i.imgur.com/w7ZyWPg.jpg"
   :data:

--- a/test/dummy/app/components/card/card_component.rb
+++ b/test/dummy/app/components/card/card_component.rb
@@ -1,19 +1,14 @@
 class CardComponent < MountainView::Presenter
-  properties :title, :description, :link, :image_url
+  include ActionView::Helpers::TagHelper
+  
+  properties :title, :description, :link, :image_url, :location
   property :data, default: []
-  property :foobar
 
   def title
-    ["Foobar", properties[:title]].join(" - ")
+    [location, properties[:title]].compact.join(", ")
   end
-
-  def foobar
-    h.content_tag(:p, "Foobar!!")
-  end
-
-  private
-
-  def h
-    ActionController::Base.helpers
+  
+  def has_description?
+    description.present?
   end
 end

--- a/test/dummy/app/components/card/card_component.rb
+++ b/test/dummy/app/components/card/card_component.rb
@@ -1,7 +1,7 @@
 class CardComponent < MountainView::Presenter
-  attributes :title, :description, :link, :image_url
-  attribute :data, default: []
-  attribute :foobar
+  properties :title, :description, :link, :image_url
+  property :data, default: []
+  property :foobar
 
   def title
     ["Foobar", properties[:title]].join(" - ")

--- a/test/mountain_view/presenter_test.rb
+++ b/test/mountain_view/presenter_test.rb
@@ -14,20 +14,6 @@ class MountainViewPresenterTest < ActiveSupport::TestCase
     assert_equal "header/header", presenter.partial
   end
 
-  def test_locals
-    properties = { name: "Foo", title: "Bar" }
-    presenter = MountainView::Presenter.new("header", properties)
-    assert_equal add_properties(properties), presenter.locals
-  end
-
-  def test_inherited_locals
-    properties = { name: "Foo", title: "Bar" }
-    presenter = InheritedPresenter.new("header", properties)
-    presenter_properties = { title: "Foobar", description: nil, data: [] }
-    expected_properties = properties.merge(presenter_properties)
-    assert_equal add_properties(expected_properties), presenter.locals
-  end
-
   def add_properties(properties)
     properties.merge(properties: properties)
   end

--- a/test/mountain_view/presenter_test.rb
+++ b/test/mountain_view/presenter_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+
 class InheritedPresenter < MountainView::Presenter
   properties :title, :description
   property :data, default: []
@@ -8,13 +9,30 @@ class InheritedPresenter < MountainView::Presenter
   end
 end
 
-class MountainViewPresenterTest < ActiveSupport::TestCase
-  def test_partial
+class MountainView::PresenterTest < ActiveSupport::TestCase
+  test 'returns the correct partial path' do
     presenter = MountainView::Presenter.new("header")
     assert_equal "header/header", presenter.partial
   end
-
-  def add_properties(properties)
-    properties.merge(properties: properties)
+  
+  test 'exposes properties as provided' do
+    properties = {:foo => 'bar', :hello => 'world'}
+    presenter = MountainView::Presenter.new("header", properties)
+    assert_equal properties, presenter.properties
+  end
+  
+  test 'inherited presenter returns the correct title' do
+    presenter = InheritedPresenter.new('inherited', {:title => 'Bar'})
+    assert_equal 'Foobar', presenter.title
+  end
+  
+  test 'inherited presenter responds to #data' do
+    presenter = InheritedPresenter.new('inherited', {:data => ['Foobar']})
+    assert_equal ['Foobar'], presenter.data
+  end
+  
+  test 'inherited presenter returns the default value for #data' do
+    presenter = InheritedPresenter.new('inherited', {})
+    assert_equal [], presenter.data
   end
 end


### PR DESCRIPTION
This exposes the presenter's public methods to the view context used when rendering the component, instead of just setting the local variables when rendering. This allows for use of any method, a la 'helper methods', which is a lot more flexible than a hash of variables. 

It does this by adding delegators on the view context for each of the presenter's public methods. To facilitate this it also defines readers for the properties set against the component class, which is useful when defining other methods for the component.

I think this works a lot better than my previous implementation, but I'm very open to any comments!
